### PR TITLE
ci: reduce PR latency for stacked transport migration

### DIFF
--- a/.github/workflows/bundled-lint-and-test.yaml
+++ b/.github/workflows/bundled-lint-and-test.yaml
@@ -140,42 +140,14 @@ jobs:
         run: |
           echo "cache_key: ${{ env.CACHE_KEY }}"
 
-      - name: Install dependencies
-        run: |
-          cargo install cargo-tarpaulin
       - name: Show toolchain information
         working-directory: ${{github.workspace}}
         run: |
           rustup toolchain list
           cargo --version
-      - name: Run tests and report code coverage
+      - name: Run tests
         run: |
-          # enable nightly features so that we can also include Doctests
-          LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${VSOMEIP_INSTALL_PATH}/lib RUSTC_BOOTSTRAP=1 cargo tarpaulin -o xml -o lcov -o html --doc --tests -- --test-threads 1
-
-      - name: Upload coverage report (xml)
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Coverage Results (xml)
-          path: cobertura.xml
-
-      - name: Upload coverage report (lcov)
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Coverage Results (lcov)
-          path: lcov.info
-
-      - name: Upload coverage report (html)
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Coverage Results (html)
-          path: tarpaulin-report.html
-
-      # - name: Upload coverage report
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: Code coverage report
-      #     path: cobertura.xml
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${VSOMEIP_INSTALL_PATH}/lib cargo test --doc --tests -- --test-threads 1
 
   build-docs:
     name: Build documentation
@@ -212,4 +184,3 @@ jobs:
       - name: Create Documentation for up-linux-streamer
         working-directory: ${{github.workspace}}
         run: RUSTDOCFLAGS=-Dwarnings cargo doc -p up-linux-streamer --no-deps
-

--- a/.github/workflows/bundled-lint-and-test.yaml
+++ b/.github/workflows/bundled-lint-and-test.yaml
@@ -91,6 +91,9 @@ jobs:
           rustup show
           rustup component add rustfmt clippy
 
+      - name: Cache Rust dependencies and build outputs
+        uses: swatinem/rust-cache@v2
+
       - name: Build the project without Zenoh & vsomeip transports
         working-directory: ${{github.workspace}}
         run: cargo build
@@ -119,6 +122,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies and build outputs
+        uses: swatinem/rust-cache@v2
 
       - name: Install C++ dependencies
         run: sudo apt-get install -y build-essential cmake libboost-all-dev libclang-dev
@@ -160,6 +166,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache Rust dependencies and build outputs
+        uses: swatinem/rust-cache@v2
 
       - name: Install C++ dependencies
         run: sudo apt-get install -y build-essential cmake libboost-all-dev libclang-dev

--- a/.github/workflows/nightly-coverage.yaml
+++ b/.github/workflows/nightly-coverage.yaml
@@ -1,0 +1,105 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+name: Nightly Coverage
+
+env:
+  VSOMEIP_INSTALL_PATH: vsomeip-install
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+concurrency:
+      group: ${{ github.ref }}-${{ github.workflow }}
+      cancel-in-progress: true
+
+jobs:
+  set-env:
+    name: Set environment variables
+    runs-on: ubuntu-22.04
+
+    outputs:
+      arch_specific_cpp_stdlib_path: ${{ steps.set_env.outputs.arch_specific_cpp_stdlib_path }}
+      generic_cpp_stdlib_path: ${{ steps.set_env.outputs.generic_cpp_stdlib_path }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add execute permissions for envsetup
+        run: chmod +x build/envsetup.sh
+
+      - name: Set stdlib paths dynamically
+        id: set_env
+        run: |
+          source ./build/envsetup.sh highest
+          echo "arch_specific_cpp_stdlib_path=$ARCH_SPECIFIC_CPP_STDLIB_PATH" >> $GITHUB_OUTPUT
+          echo "generic_cpp_stdlib_path=$GENERIC_CPP_STDLIB_PATH" >> $GITHUB_OUTPUT
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-22.04
+    needs: set-env
+
+    env:
+       ARCH_SPECIFIC_CPP_STDLIB_PATH: ${{ needs.set-env.outputs.arch_specific_cpp_stdlib_path }}
+       GENERIC_CPP_STDLIB_PATH: ${{ needs.set-env.outputs.generic_cpp_stdlib_path }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install C++ dependencies
+        run: sudo apt-get install -y build-essential cmake libboost-all-dev libclang-dev
+
+      - name: Set environment variables
+        run: |
+          echo "VSOMEIP_INSTALL_PATH=${{ github.workspace }}/${{ env.VSOMEIP_INSTALL_PATH }}" >> $GITHUB_ENV
+
+      - name: Ensure vsomeip install path exists
+        run: |
+          mkdir -p ${{ env.VSOMEIP_INSTALL_PATH }}
+
+      - name: Install dependencies
+        run: cargo install cargo-tarpaulin
+
+      - name: Show toolchain information
+        working-directory: ${{github.workspace}}
+        run: |
+          rustup toolchain list
+          cargo --version
+
+      - name: Run tests and report code coverage
+        run: |
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${VSOMEIP_INSTALL_PATH}/lib RUSTC_BOOTSTRAP=1 cargo tarpaulin -o xml -o lcov -o html --doc --tests -- --test-threads 1
+
+      - name: Upload coverage report (xml)
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Coverage Results (xml)
+          path: cobertura.xml
+
+      - name: Upload coverage report (lcov)
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Coverage Results (lcov)
+          path: lcov.info
+
+      - name: Upload coverage report (html)
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Coverage Results (html)
+          path: tarpaulin-report.html

--- a/.github/workflows/unbundled-lint-and-test.yaml
+++ b/.github/workflows/unbundled-lint-and-test.yaml
@@ -192,6 +192,9 @@ jobs:
           rustup show
           rustup component add rustfmt clippy
 
+      - name: Cache Rust dependencies and build outputs
+        uses: swatinem/rust-cache@v2
+
       - name: Build the project with Zenoh & vsomeip transports (and thus streamer references)
         working-directory: ${{github.workspace}}
         run: cargo build --features vsomeip-transport,zenoh-transport,mqtt-transport
@@ -246,6 +249,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vsomeip-
 
+      - name: Cache Rust dependencies and build outputs
+        uses: swatinem/rust-cache@v2
+
       - name: Show toolchain information
         working-directory: ${{github.workspace}}
         run: |
@@ -296,6 +302,9 @@ jobs:
           key: ${{ env.CACHE_KEY }}
           restore-keys: |
             ${{ runner.os }}-vsomeip-
+
+      - name: Cache Rust dependencies and build outputs
+        uses: swatinem/rust-cache@v2
 
       - name: Create Documentation for up-streamer
         working-directory: ${{github.workspace}}

--- a/.github/workflows/unbundled-lint-and-test.yaml
+++ b/.github/workflows/unbundled-lint-and-test.yaml
@@ -192,21 +192,12 @@ jobs:
           rustup show
           rustup component add rustfmt clippy
 
-      - name: Build the project without Zenoh & vsomeip transports
-        working-directory: ${{github.workspace}}
-        run: cargo build
-      - name: cargo clippy without Zenoh & vsomeip transports
-        working-directory: ${{github.workspace}}
-        run: cargo clippy --all-targets -- -W warnings -D warnings
       - name: Build the project with Zenoh & vsomeip transports (and thus streamer references)
         working-directory: ${{github.workspace}}
         run: cargo build --features vsomeip-transport,zenoh-transport,mqtt-transport
       - name: cargo clippy with Zenoh & vsomeip transports (and thus streamer references)
         working-directory: ${{github.workspace}}
         run: cargo clippy --features vsomeip-transport,zenoh-transport,mqtt-transport --all-targets -- -W warnings -D warnings
-      - name: cargo fmt
-        working-directory: ${{github.workspace}}
-        run: cargo fmt -- --check
 
   test:
     name: Test

--- a/.github/workflows/unbundled-lint-and-test.yaml
+++ b/.github/workflows/unbundled-lint-and-test.yaml
@@ -255,42 +255,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vsomeip-
 
-      - name: Install dependencies
-        run: |
-          cargo install cargo-tarpaulin
       - name: Show toolchain information
         working-directory: ${{github.workspace}}
         run: |
           rustup toolchain list
           cargo --version
-      - name: Run tests and report code coverage
+      - name: Run tests
         run: |
-          # enable nightly features so that we can also include Doctests
-          LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${VSOMEIP_INSTALL_PATH}/lib RUSTC_BOOTSTRAP=1 cargo tarpaulin --no-default-features -o xml -o lcov -o html --doc --tests -- --test-threads 1
-
-      - name: Upload coverage report (xml)
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Coverage Results (xml)
-          path: cobertura.xml
-
-      - name: Upload coverage report (lcov)
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Coverage Results (lcov)
-          path: lcov.info
-
-      - name: Upload coverage report (html)
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Coverage Results (html)
-          path: tarpaulin-report.html
-
-      # - name: Upload coverage report
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: Code coverage report
-      #     path: cobertura.xml
+          LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${VSOMEIP_INSTALL_PATH}/lib cargo test --no-default-features --doc --tests -- --test-threads 1
 
   build-docs:
     name: Build documentation


### PR DESCRIPTION
## Summary
- Remove tarpaulin coverage from PR `Test` jobs and run standard functional tests in bundled/unbundled workflows.
- Add a dedicated `Nightly Coverage` workflow triggered on nightly schedule, manual dispatch, and `main` pushes.
- De-duplicate unbundled lint work and add Rust dependency/target caching to compile-heavy CI jobs.

## Validation
- PR workflow run status: pending
- Manual nightly coverage dispatch: pending

## Timing (Bundled/Unbundled Lint+Test)
| Workflow | Job | Before | After | Delta |
| --- | --- | --- | --- | --- |
| Bundled | Lint | 12m21s | pending | pending |
| Bundled | Test | 9m18s | pending | pending |
| Unbundled | Lint | 9m01s | pending | pending |
| Unbundled | Test | 9m05s | pending | pending |